### PR TITLE
Fix async_read timeout in Boost.Beast agent

### DIFF
--- a/source/agents/beast/banana/agent/beast.cpp
+++ b/source/agents/beast/banana/agent/beast.cpp
@@ -74,6 +74,9 @@ std::string do_blocking_request(
         current_state = "write";
         [[maybe_unused]] std::size_t bytes_sent = boost::beast::http::write(stream, req);
 
+        // Set a timeout on the operation
+        boost::beast::get_lowest_layer(stream).expires_after(std::chrono::seconds(60));
+
         // Receive the HTTP response
         current_state = "read";
         boost::beast::flat_buffer buffer; // (Must persist between reads)
@@ -180,6 +183,9 @@ public:
         if (ec) {
             return on_fail(ec, "write");
         }
+
+        // Set a timeout on the operation
+        boost::beast::get_lowest_layer(m_stream).expires_after(std::chrono::seconds(60));
 
         // Receive the HTTP response
         boost::beast::http::async_read(m_stream, m_buffer, m_res, boost::beast::bind_front_handler(&basic_http_session::on_read, shared_from_this()));


### PR DESCRIPTION
Timeout set before async_write was not reset before async_read, so it limited maximum long-poll timeout to 30 seconds. Telegram long-polling seems to support timeout for up to 50 seconds, so I set async_read timeout to 60 seconds.